### PR TITLE
Fix the expected return type for array filter

### DIFF
--- a/daily_guides/day_3/GUIDE.MD
+++ b/daily_guides/day_3/GUIDE.MD
@@ -209,7 +209,7 @@ The [Array module](https://internetcomputer.org/docs/current/developer-docs/buil
             };
         };
 
-        public func surprise(array : [Nat]) : async ?Nat {
+        public func surprise(array : [Nat]) : async [Nat] {
             return(Array.filter<Nat>(array, f));
         };
     };


### PR DESCRIPTION
The return type should be an array that passed the logic of higher order function